### PR TITLE
feat: enable running on containerd

### DIFF
--- a/kubernetes/templates/ui/configmap-caddy.yaml
+++ b/kubernetes/templates/ui/configmap-caddy.yaml
@@ -12,7 +12,7 @@ data:
       admin :5555
     }
 
-    :80 {
+    :8080 {
 
         handle /api/v1/* {
             reverse_proxy {{ include "kubevious-backend.service.name" . }}:{{ .Values.backend.service.port }}

--- a/kubernetes/templates/ui/deployment.yaml
+++ b/kubernetes/templates/ui/deployment.yaml
@@ -40,7 +40,7 @@ spec:
               value: {{ .Chart.Version }}              
           ports:
             - name: http
-              containerPort: 80
+              containerPort: 8080
               protocol: TCP
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Running the UI on containerd crashes because running on port 80 does not work (no matter which user you choose). Changing to a non-80 port fixes this.